### PR TITLE
Fix Surfer Vandersloot's profile image on mobile

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1121,8 +1121,7 @@ footer {
     margin-bottom: 1rem;
   }
   .anna, 
-  .beurdouche,
-  .vandersloot {
+  .beurdouche {
     max-block-size: 10rem;
   }
 


### PR DESCRIPTION
Tiny PR to adjust Vandersloot's profile image to prevent it from being cut off on mobile screens. 
<table>
<tr>
<th>
Before
</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="335" alt="Screenshot 2025-04-08 at 10 01 01 AM" src="https://github.com/user-attachments/assets/eb97938f-bc84-4cce-bdb4-579642a18295" />

</td>
<td>
<img width="358" alt="Screenshot 2025-04-08 at 10 01 13 AM" src="https://github.com/user-attachments/assets/b757e1b1-76b6-4d2f-9c9e-dfa3fa35631f" />

</td>
</tr>
</table>